### PR TITLE
💚 fix: bundle analysis

### DIFF
--- a/.storybook/index.css
+++ b/.storybook/index.css
@@ -1,0 +1,7 @@
+:root {
+  --font-noto-sans-jp: "__Noto_Sans_JP_299c68", "__Noto_Sans_JP_Fallback_299c68";
+}
+
+body {
+  font-family: var(--font-noto-sans-jp);
+}

--- a/.storybook/mocks/context.tsx
+++ b/.storybook/mocks/context.tsx
@@ -1,15 +1,14 @@
-import { defaultMockRouter } from "mocks/next/router";
-import { AppRouterContext } from "mocks/next/router";
-import { SearchProvider } from "@/components/organisms/SearchArea/SearchContext";
-import { createMockRouterHoc } from "mocks/next/router";
 import React from "react";
 
+import { createMockRouterHoc, defaultMockRouter } from "mocks/next/router";
+import { defaultMockLegacyRouter, withMockLegacyRouter } from "mocks/next/legacy-router";
+
+import { SearchProvider } from "@/components/organisms/SearchArea/SearchContext";
+
 export const withContext = (Story: React.ReactElement) => {
-  return (
-    <AppRouterContext.Provider value={defaultMockRouter}>
-      <SearchProvider>{Story}</SearchProvider>
-    </AppRouterContext.Provider>
-  );
+  return withMockLegacyRouter(withRouterContext(<SearchProvider>{Story}</SearchProvider>));
 };
 
 export const withRouterContext = createMockRouterHoc();
+
+export { defaultMockLegacyRouter, defaultMockRouter, withMockLegacyRouter };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,5 @@
 import "@/styles/global.css";
+import "./index.css";
 
 import { withPerformance } from "storybook-addon-performance";
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";

--- a/jest/mocks/index.ts
+++ b/jest/mocks/index.ts
@@ -1,2 +1,8 @@
-export type { AppRouterInstance } from "./router";
-export { AppRouterContext, defaultMockRouter, withMockRouter } from "./router";
+export type { AppRouterInstance, NextRouter } from "./router";
+export {
+  AppRouterContext,
+  defaultMockLegacyRouter,
+  defaultMockRouter,
+  withMockLegacyRouter,
+  withMockRouter,
+} from "./router";

--- a/jest/mocks/index.ts
+++ b/jest/mocks/index.ts
@@ -6,3 +6,4 @@ export {
   withMockLegacyRouter,
   withMockRouter,
 } from "./router";
+export { defaultMockSearchMutation, defaultSearchState, withMockSearchContext } from "./search";

--- a/jest/mocks/router.tsx
+++ b/jest/mocks/router.tsx
@@ -1,5 +1,7 @@
+import { withMockLegacyRouter } from "mocks/next/legacy-router";
 import type { AppRouterInstance, HooksClientContext } from "mocks/next/router";
 import { AppRouterContext, createMockRouterHoc } from "mocks/next/router";
+import type { NextRouter } from "next/router";
 
 export const defaultMockRouter: AppRouterInstance = {
   back: jest.fn(),
@@ -16,3 +18,30 @@ export const withMockRouter = createMockRouterHoc({
 
 export { AppRouterContext };
 export type { AppRouterInstance, HooksClientContext };
+
+export const defaultMockLegacyRouter: NextRouter = {
+  asPath: "/",
+  back: jest.fn(),
+  basePath: "/",
+  beforePopState: jest.fn(),
+  events: {
+    emit: jest.fn(),
+    off: jest.fn(),
+    on: jest.fn(),
+  },
+  forward: jest.fn(),
+  isFallback: false,
+  isLocaleDomain: true,
+  isPreview: false,
+  isReady: true,
+  pathname: "/",
+  prefetch: jest.fn(),
+  push: jest.fn(),
+  query: {},
+  reload: jest.fn(),
+  replace: jest.fn(),
+  route: "/",
+};
+
+export type { NextRouter };
+export { withMockLegacyRouter };

--- a/jest/mocks/router.tsx
+++ b/jest/mocks/router.tsx
@@ -1,4 +1,4 @@
-import { withMockLegacyRouter } from "mocks/next/legacy-router";
+import { withMockLegacyRouter as BaseWithMockLegacyRouter } from "mocks/next/legacy-router";
 import type { AppRouterInstance, HooksClientContext } from "mocks/next/router";
 import { AppRouterContext, createMockRouterHoc } from "mocks/next/router";
 import type { NextRouter } from "next/router";
@@ -41,6 +41,14 @@ export const defaultMockLegacyRouter: NextRouter = {
   reload: jest.fn(),
   replace: jest.fn(),
   route: "/",
+};
+
+const withMockLegacyRouter = (children: React.ReactElement, router?: Partial<NextRouter>) => {
+  const mockRouter = {
+    ...defaultMockLegacyRouter,
+    ...router,
+  };
+  return BaseWithMockLegacyRouter(children, mockRouter);
 };
 
 export type { NextRouter };

--- a/jest/mocks/search.tsx
+++ b/jest/mocks/search.tsx
@@ -1,0 +1,31 @@
+import type {
+  SearchMutation,
+  SearchProviderInnerProps,
+  SearchState,
+} from "@/components/organisms/SearchArea/SearchContext";
+import { defaultSearchState, SearchProviderInner } from "@/components/organisms/SearchArea/SearchContext";
+
+export const defaultMockSearchMutation: SearchMutation = {
+  setHistory: jest.fn(),
+  setSelectedCategory: jest.fn(),
+  setSelectedTags: jest.fn(),
+  setText: jest.fn(),
+};
+
+export const withMockSearchContext = (
+  children: React.ReactElement,
+  state?: Partial<SearchProviderInnerProps["state"]>
+): React.ReactElement => {
+  const mockSearchState: SearchState = {
+    ...defaultSearchState,
+    ...state,
+  };
+
+  return (
+    <SearchProviderInner state={mockSearchState} mutation={defaultMockSearchMutation}>
+      {children}
+    </SearchProviderInner>
+  );
+};
+
+export { defaultSearchState };

--- a/jest/test-utils.tsx
+++ b/jest/test-utils.tsx
@@ -7,13 +7,15 @@ import { SWRConfig } from "swr";
 
 import { SearchProvider } from "@/components/organisms/SearchArea/SearchContext";
 
-import { withMockRouter } from "./mocks";
+import { withMockLegacyRouter, withMockRouter } from "./mocks";
 
 export const Providers: React.ComponentType<{ children?: React.ReactNode }> = ({ children }) => {
   return withMockRouter(
-    <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map() }}>
-      <SearchProvider>{children}</SearchProvider>
-    </SWRConfig>
+    withMockLegacyRouter(
+      <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map() }}>
+        <SearchProvider>{children}</SearchProvider>
+      </SWRConfig>
+    )
   );
 };
 
@@ -26,7 +28,7 @@ export * from "./mocks";
 export * from "@testing-library/react";
 
 // override render method
-export { customRender as render };
+export { render as originalRender, customRender as render };
 
 export const reTestCase = {
   anyImage: expect.stringMatching(/^(data:image\/gif)|\.(png|webp|jpeg|jpg|svg)$/),

--- a/mocks/next/legacy-router.tsx
+++ b/mocks/next/legacy-router.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { RouterContext } from "next/dist/shared/lib/router-context";
+import type { NextRouter } from "next/router";
+
+export type { NextRouter };
+export { RouterContext };
+
+export const defaultMockLegacyRouter: NextRouter = {
+  asPath: "/",
+  back: () => {},
+  basePath: "/",
+  beforePopState: () => {},
+  events: {
+    emit: () => {},
+    off: () => {},
+    on: () => {},
+  },
+  forward: () => {},
+  isFallback: false,
+  isLocaleDomain: true,
+  isPreview: false,
+  isReady: true,
+  pathname: "/",
+  prefetch: async (_url) => {},
+  push: async (_url) => true,
+  query: {},
+  reload: () => {},
+  replace: async (_url) => true,
+  route: "/",
+};
+
+export const withMockLegacyRouter = (
+  children: React.ReactElement,
+  router: Partial<NextRouter> = {}
+): React.ReactElement => {
+  const mockRouter: NextRouter = {
+    ...defaultMockLegacyRouter,
+    ...router,
+  };
+
+  return <RouterContext.Provider value={mockRouter}>{children}</RouterContext.Provider>;
+};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@google-analytics/data": "3.1.1",
     "@headlessui/react": "1.7.4",
+    "@next/font": "13.0.6",
     "@sentry/nextjs": "7.23.0",
     "@tailwindcss/line-clamp": "0.4.2",
     "@tailwindcss/typography": "^0.5.8",
@@ -56,7 +57,6 @@
     "remark-slug": "7.0.1",
     "remark-unwrap-images": "3.0.1",
     "sharp": "0.31.2",
-    "slick-carousel": "1.8.1",
     "swr": "^1.3.0",
     "tocbot": "4.19.0",
     "zod": "3.19.1"
@@ -109,7 +109,6 @@
     "npm-run-all": "4.1.5",
     "postcss": "8.4.19",
     "prettier": "2.8.0",
-    "storybook-addon-next": "1.7.1",
     "storybook-addon-performance": "0.16.1",
     "storybook-tailwind-dark-mode": "1.0.15",
     "tailwindcss": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ specifiers:
   '@google-analytics/data': 3.1.1
   '@headlessui/react': 1.7.4
   '@next/bundle-analyzer': 13.0.6
+  '@next/font': 13.0.6
   '@playwright/test': 1.28.1
   '@sentry/nextjs': 7.23.0
   '@storybook/addon-a11y': 6.5.14
@@ -74,8 +75,6 @@ specifiers:
   remark-slug: 7.0.1
   remark-unwrap-images: 3.0.1
   sharp: 0.31.2
-  slick-carousel: 1.8.1
-  storybook-addon-next: 1.7.1
   storybook-addon-performance: 0.16.1
   storybook-tailwind-dark-mode: 1.0.15
   swr: ^1.3.0
@@ -88,6 +87,7 @@ specifiers:
 dependencies:
   '@google-analytics/data': 3.1.1
   '@headlessui/react': 1.7.4_biqbaboplfbrettd7655fr4n2y
+  '@next/font': 13.0.6
   '@sentry/nextjs': 7.23.0_ivfizlltnf5oincobffrvntlsq
   '@tailwindcss/line-clamp': 0.4.2_tailwindcss@3.2.4
   '@tailwindcss/typography': 0.5.8_tailwindcss@3.2.4
@@ -112,7 +112,6 @@ dependencies:
   remark-slug: 7.0.1
   remark-unwrap-images: 3.0.1
   sharp: 0.31.2
-  slick-carousel: 1.8.1
   swr: 1.3.0_react@18.2.0
   tocbot: 4.19.0
   zod: 3.19.1
@@ -165,7 +164,6 @@ devDependencies:
   npm-run-all: 4.1.5
   postcss: 8.4.19
   prettier: 2.8.0
-  storybook-addon-next: 1.7.1_qecw2j3r6s2t7xkqh4ufvbdp24
   storybook-addon-performance: 0.16.1_2zx2umvpluuhvlq44va5bta2da
   storybook-tailwind-dark-mode: 1.0.15_biqbaboplfbrettd7655fr4n2y
   tailwindcss: 3.2.4_postcss@8.4.19
@@ -2125,6 +2123,10 @@ packages:
     dependencies:
       glob: 7.1.7
     dev: true
+
+  /@next/font/13.0.6:
+    resolution: {integrity: sha512-5vxNmvnV0CbYjQGtztD5Axft9C7npKihbQpiFhnDwdb99f9K/QSFfcJqxz0E5QBkf67O2niVGJ5lApJDu78w0w==}
+    dev: false
 
   /@next/swc-android-arm-eabi/13.0.6:
     resolution: {integrity: sha512-FGFSj3v2Bluw8fD/X+1eXIEB0PhoJE0zfutsAauRhmNpjjZshLDgoXMWm1jTRL/04K/o9gwwO2+A8+sPVCH1uw==}
@@ -4964,14 +4966,6 @@ packages:
   /address/1.2.1:
     resolution: {integrity: sha512-B+6bi5D34+fDYENiH5qOlA0cV2rAGKuWZ9LeyUUehbXy8e0VS9e498yO0Jeeh+iM+6KbfudHTFjXw2MmJD4QRA==}
     engines: {node: '>= 10.0.0'}
-    dev: true
-
-  /adjust-sourcemap-loader/4.0.0:
-    resolution: {integrity: sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==}
-    engines: {node: '>=8.9'}
-    dependencies:
-      loader-utils: 2.0.4
-      regex-parser: 2.2.11
     dev: true
 
   /agent-base/6.0.2:
@@ -9440,6 +9434,7 @@ packages:
     hasBin: true
     dependencies:
       queue: 6.0.2
+    dev: false
 
   /immediate/3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -11011,11 +11006,6 @@ packages:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.1
-
-  /loader-utils/3.2.1:
-    resolution: {integrity: sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==}
-    engines: {node: '>= 12.13.0'}
-    dev: true
 
   /localforage/1.10.0:
     resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
@@ -13122,20 +13112,6 @@ packages:
       webpack: 5.75.0
     dev: true
 
-  /postcss-loader/7.0.2_upg3rk2kpasnbk27hkqapxaxfq:
-    resolution: {integrity: sha512-fUJzV/QH7NXUAqV8dWJ9Lg4aTkDCezpTS5HgJ2DvqznexTbSTxgi/dTECvTZ15BwKTtk8G/bqI/QTu2HPd3ZCg==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      postcss: ^7.0.0 || ^8.0.1
-      webpack: ^5.0.0
-    dependencies:
-      cosmiconfig: 7.1.0
-      klona: 2.0.5
-      postcss: 8.4.19
-      semver: 7.3.8
-      webpack: 5.75.0
-    dev: true
-
   /postcss-modules-extract-imports/2.0.0:
     resolution: {integrity: sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==}
     engines: {node: '>= 6'}
@@ -13569,6 +13545,7 @@ packages:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
     dependencies:
       inherits: 2.0.4
+    dev: false
 
   /quick-lru/5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
@@ -13890,10 +13867,6 @@ packages:
       safe-regex: 1.1.0
     dev: true
 
-  /regex-parser/2.2.11:
-    resolution: {integrity: sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==}
-    dev: true
-
   /regexp.prototype.flags/1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
@@ -14152,17 +14125,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /resolve-url-loader/5.0.0:
-    resolution: {integrity: sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==}
-    engines: {node: '>=12'}
-    dependencies:
-      adjust-sourcemap-loader: 4.0.0
-      convert-source-map: 1.9.0
-      loader-utils: 2.0.4
-      postcss: 8.4.19
-      source-map: 0.6.1
-    dev: true
-
   /resolve-url/0.2.1:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
     deprecated: https://github.com/lydell/resolve-url#deprecated
@@ -14346,30 +14308,6 @@ packages:
       walker: 1.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /sass-loader/13.2.0_webpack@5.75.0:
-    resolution: {integrity: sha512-JWEp48djQA4nbZxmgC02/Wh0eroSUutulROUusYJO9P9zltRbNN80JCBHqRGzjd4cmZCa/r88xgfkjGD0TXsHg==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      fibers: '>= 3.1.0'
-      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-      sass: ^1.3.0
-      sass-embedded: '*'
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      fibers:
-        optional: true
-      node-sass:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-    dependencies:
-      klona: 2.0.5
-      neo-async: 2.6.2
-      webpack: 5.75.0
     dev: true
 
   /sax/1.2.4:
@@ -14676,12 +14614,6 @@ packages:
       is-fullwidth-code-point: 4.0.0
     dev: true
 
-  /slick-carousel/1.8.1:
-    resolution: {integrity: sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==}
-    peerDependencies:
-      jquery: '>=1.8.0'
-    dev: false
-
   /snapdragon-node/2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
     engines: {node: '>=0.10.0'}
@@ -14863,36 +14795,6 @@ packages:
 
   /store2/2.14.2:
     resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
-    dev: true
-
-  /storybook-addon-next/1.7.1_qecw2j3r6s2t7xkqh4ufvbdp24:
-    resolution: {integrity: sha512-SSbD91CUNSKiTMYfbqBGUkbRuSiC7+q7D4bRqDgHI2kSJn4wi99/ccFVGCegTRJoJqljwtEJ/vEqQ253L64hVQ==}
-    peerDependencies:
-      '@storybook/addon-actions': ^6.0.0
-      next: ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/addon-actions': 6.5.14_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addons': 6.5.14_biqbaboplfbrettd7655fr4n2y
-      image-size: 1.0.2
-      loader-utils: 3.2.1
-      next: 13.0.6_672uxklweod7ene3nqtsh262ca
-      postcss-loader: 7.0.2_upg3rk2kpasnbk27hkqapxaxfq
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      resolve-url-loader: 5.0.0
-      sass-loader: 13.2.0_webpack@5.75.0
-      semver: 7.3.8
-      tsconfig-paths: 4.1.1
-      tsconfig-paths-webpack-plugin: 4.0.0
-    transitivePeerDependencies:
-      - fibers
-      - node-sass
-      - postcss
-      - sass
-      - sass-embedded
-      - webpack
     dev: true
 
   /storybook-addon-performance/0.16.1_2zx2umvpluuhvlq44va5bta2da:
@@ -15705,29 +15607,11 @@ packages:
       typescript: 4.9.3
     dev: true
 
-  /tsconfig-paths-webpack-plugin/4.0.0:
-    resolution: {integrity: sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==}
-    engines: {node: '>=10.13.0'}
-    dependencies:
-      chalk: 4.1.2
-      enhanced-resolve: 5.12.0
-      tsconfig-paths: 4.1.1
-    dev: true
-
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.1
-      minimist: 1.2.7
-      strip-bom: 3.0.0
-    dev: true
-
-  /tsconfig-paths/4.1.1:
-    resolution: {integrity: sha512-VgPrtLKpRgEAJsMj5Q/I/mXouC6A/7eJ/X4Nuk6o0cRPwBtznYxTCU4FodbexbzH9somBPEXYi0ZkUViUpJ21Q==}
-    engines: {node: '>=6'}
-    dependencies:
-      json5: 2.2.1
       minimist: 1.2.7
       strip-bom: 3.0.0
     dev: true

--- a/src/components/atoms/Avatar/index.tsx
+++ b/src/components/atoms/Avatar/index.tsx
@@ -9,6 +9,6 @@ type AvatarProps = {
 export const Avatar: React.FC<AvatarProps> = (props) => {
   return (
     // eslint-disable-next-line jsx-a11y/alt-text
-    <Image {...props} className="m-0 rounded-full border border-gray-100 bg-pink-700" />
+    <Image {...props} className="m-0 rounded-full border border-gray-100" />
   );
 };

--- a/src/components/molecules/BackLinks/index.stories.tsx
+++ b/src/components/molecules/BackLinks/index.stories.tsx
@@ -1,13 +1,13 @@
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import BackLinks from ".";
-import { withRouterContext } from ".storybook/mocks/context";
+import { withContext } from ".storybook/mocks/context";
 
 export default {
   component: BackLinks,
   decorators: [
     (storyFn) => {
-      return withRouterContext(storyFn());
+      return withContext(storyFn());
     },
   ],
   title: "molecules/BackLinks",

--- a/src/components/molecules/category/CategoryMenu/index.stories.tsx
+++ b/src/components/molecules/category/CategoryMenu/index.stories.tsx
@@ -2,13 +2,13 @@ import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import { mockCategories } from "mocks/data/categories";
 
 import { CategoryMenu } from ".";
-import { withRouterContext } from ".storybook/mocks/context";
+import { withContext } from ".storybook/mocks/context";
 
 export default {
   component: CategoryMenu,
   decorators: [
     (storyFn) => {
-      return withRouterContext(storyFn());
+      return withContext(storyFn());
     },
   ],
   title: "molecules/category/CategoryMenu",

--- a/src/components/organisms/Header/index.stories.tsx
+++ b/src/components/organisms/Header/index.stories.tsx
@@ -2,7 +2,7 @@ import type { ComponentMeta, ComponentStoryObj } from "@storybook/react";
 import { mockCategories } from "mocks/data";
 
 import Header from ".";
-import { withRouterContext } from ".storybook/mocks/context";
+import { withContext } from ".storybook/mocks/context";
 import { device } from ".storybook/mocks/device";
 
 export default {
@@ -17,7 +17,7 @@ export const Desktop: ComponentStoryObj<typeof Header> = {
   },
   decorators: [
     (storyFn) => {
-      return withRouterContext(storyFn());
+      return withContext(storyFn());
     },
   ],
 };

--- a/src/components/organisms/SearchArea/SearchBar/index.spec.tsx
+++ b/src/components/organisms/SearchArea/SearchBar/index.spec.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { defaultMockRouter, render, screen, withMockRouter } from "jest/test-utils";
+import { defaultMockLegacyRouter, render, screen, withMockLegacyRouter, withMockRouter } from "jest/test-utils";
 
 import SearchBar from ".";
 
@@ -31,7 +31,7 @@ describe("components/organisms/SearchArea/SearchBar", () => {
     });
 
     it("OK: 検索イベント", async () => {
-      render(withMockRouter(<SearchBar />));
+      render(withMockRouter(withMockLegacyRouter(<SearchBar />)));
       const input = screen.getByRole("combobox");
       expect(input).toHaveValue("");
 
@@ -40,7 +40,9 @@ describe("components/organisms/SearchArea/SearchBar", () => {
       expect(input).toHaveValue(testText);
 
       await user.type(input, "{enter}");
-      expect(defaultMockRouter.push).toBeCalledWith("/search?q=test");
+      expect(defaultMockLegacyRouter.push).toBeCalledWith({ pathname: "/search", query: { q: testText } }, undefined, {
+        shallow: true,
+      });
     });
 
     it("OK: フォーカスイベント", async () => {

--- a/src/components/organisms/SearchArea/SearchBar/index.tsx
+++ b/src/components/organisms/SearchArea/SearchBar/index.tsx
@@ -88,7 +88,7 @@ const SearchBar: React.FC = () => {
           className={`${
             text.length === 0 && history.length === 0
               ? "hidden"
-              : "fixed z-10 mt-1 mr-4 max-h-[50vh] overflow-y-auto rounded-md border border-gray-200 bg-white py-2 shadow-lg dark:border-gray-600 dark:bg-gray-700"
+              : "absolute z-10 mt-1 mr-4 max-h-[50vh] overflow-y-auto rounded-md border border-gray-200 bg-white py-2 shadow-lg dark:border-gray-600 dark:bg-gray-700"
           }`}
         >
           {text.length > 0 && (

--- a/src/components/organisms/SearchArea/SearchContext.tsx
+++ b/src/components/organisms/SearchArea/SearchContext.tsx
@@ -3,34 +3,49 @@ import { createContext, useContext, useState } from "react";
 
 import type { AllOrCategory, TTag } from "@/types";
 
-type SearchState = {
+export type SearchState = {
   text: string;
   history: string[];
   selectedCategory: AllOrCategory;
   selectedTags: TTag[];
 };
 
-type SearchMutation = {
+export type SearchMutation = {
   setText: Dispatch<SetStateAction<string>>;
   setHistory: Dispatch<SetStateAction<Array<string>>>;
   setSelectedCategory: Dispatch<SetStateAction<AllOrCategory>>;
   setSelectedTags: Dispatch<SetStateAction<Array<TTag>>>;
 };
 
-const SearchContext = createContext<SearchState>({
+export const defaultSearchState: SearchState = {
   history: [],
   selectedCategory: { id: "all", name: "すべて" },
   selectedTags: [],
   text: "",
-});
+};
+
+const SearchContext = createContext<SearchState>(defaultSearchState);
 
 const SearchMutationContext = createContext<SearchMutation>({} as SearchMutation);
 
-type Props = {
+export type SearchProviderInnerProps = {
+  children: React.ReactNode;
+  state: SearchState;
+  mutation: SearchMutation;
+};
+export const SearchProviderInner = ({ children, mutation, state }: SearchProviderInnerProps) => {
+  return (
+    <SearchContext.Provider value={state}>
+      <SearchMutationContext.Provider value={mutation}>{children}</SearchMutationContext.Provider>
+    </SearchContext.Provider>
+  );
+};
+
+type SearchProviderProps = {
   children: ReactNode;
 };
 
-export const SearchProvider = ({ children }: Props): ReactElement => {
+export const SearchProvider = ({ children }: SearchProviderProps): ReactElement => {
   const [text, setText] = useState<string>("");
   const [history, setHistory] = useState<Array<string>>([]);
   const [selectedCategory, setSelectedCategory] = useState<AllOrCategory>({
@@ -40,25 +55,12 @@ export const SearchProvider = ({ children }: Props): ReactElement => {
   const [selectedTags, setSelectedTags] = useState<Array<TTag>>([]);
 
   return (
-    <SearchContext.Provider
-      value={{
-        history,
-        selectedCategory,
-        selectedTags,
-        text,
-      }}
+    <SearchProviderInner
+      state={{ history, selectedCategory, selectedTags, text }}
+      mutation={{ setHistory, setSelectedCategory, setSelectedTags, setText }}
     >
-      <SearchMutationContext.Provider
-        value={{
-          setHistory,
-          setSelectedCategory,
-          setSelectedTags,
-          setText,
-        }}
-      >
-        {children}
-      </SearchMutationContext.Provider>
-    </SearchContext.Provider>
+      {children}
+    </SearchProviderInner>
   );
 };
 

--- a/src/components/organisms/SearchArea/SearchFilter/index.stories.tsx
+++ b/src/components/organisms/SearchArea/SearchFilter/index.stories.tsx
@@ -2,7 +2,7 @@ import type { ComponentMeta, ComponentStoryObj } from "@storybook/react";
 import { mockCategories, mockTags } from "mocks/data";
 
 import { SearchFilter } from ".";
-import { withRouterContext } from ".storybook/mocks/context";
+import { withContext } from ".storybook/mocks/context";
 
 export default {
   component: SearchFilter,
@@ -19,7 +19,7 @@ export const Default: ComponentStoryObj<typeof SearchFilter> = {
   },
   decorators: [
     (storyFn) => {
-      return withRouterContext(storyFn());
+      return withContext(storyFn());
     },
   ],
 };

--- a/src/components/organisms/SearchArea/index.stories.tsx
+++ b/src/components/organisms/SearchArea/index.stories.tsx
@@ -2,7 +2,7 @@ import type { ComponentMeta, ComponentStoryObj } from "@storybook/react";
 import { mockCategories, mockTags } from "mocks/data";
 
 import { SearchArea } from ".";
-import { withRouterContext } from ".storybook/mocks/context";
+import { withContext } from ".storybook/mocks/context";
 import { device } from ".storybook/mocks/device";
 
 export default {
@@ -17,7 +17,7 @@ export const Desktop: ComponentStoryObj<typeof SearchArea> = {
   },
   decorators: [
     (storyFn) => {
-      return withRouterContext(storyFn());
+      return withContext(storyFn());
     },
   ],
 };

--- a/src/components/pages/Search/SearchResult.tsx
+++ b/src/components/pages/Search/SearchResult.tsx
@@ -1,13 +1,15 @@
-import { useSearchState } from "@/components/organisms/SearchArea/SearchContext";
+import { useGetSearchQueryParams } from "@/components/organisms/SearchArea/useSearch";
 
 export const SearchedQueryOptions = () => {
-  const { selectedCategory, selectedTags } = useSearchState();
-  const tags = selectedTags.map((tag) => tag.name).join(" ");
+  const { category, tags } = useGetSearchQueryParams();
+  const formattedTags = tags?.split(",").join(" ");
+
+  if (!category && !tags) return null;
 
   return (
     <div className="flex flex-col space-y-2">
-      <p className="text-sm text-gray-700 dark:text-gray-300">カテゴリー: {selectedCategory.name}</p>
-      {tags && <p className="text-sm text-gray-700 dark:text-gray-300">タグ: {tags}</p>}
+      {category && <p className="text-sm text-gray-700 dark:text-gray-300">カテゴリー: {category}</p>}
+      {tags && <p className="text-sm text-gray-700 dark:text-gray-300">タグ: {formattedTags}</p>}
     </div>
   );
 };

--- a/src/components/pages/Search/index.spec.tsx
+++ b/src/components/pages/Search/index.spec.tsx
@@ -1,5 +1,5 @@
 import type { AppRouterInstance } from "jest/test-utils";
-import { render, renderHook, screen, withMockRouter } from "jest/test-utils";
+import { originalRender, renderHook, screen, withMockLegacyRouter, withMockRouter } from "jest/test-utils";
 import { mockArticles, mockCategories, mockConfig, mockPickup, mockPopularArticles, mockTags } from "mocks/data";
 
 import { formatPageTitle } from "@/utils/formatter";
@@ -20,17 +20,21 @@ describe("pages/search", () => {
   const mockCategoryList = Object.values(mockCategories);
   const mockTagList = Object.values(mockTags);
   const params = new URLSearchParams({ q: "keyword" });
+  const query = { q: "keyword" };
 
   it("OK: 初期レンダリング", () => {
-    render(
+    originalRender(
       withMockRouter(
-        <Search
-          tags={mockTagList}
-          categories={mockCategoryList}
-          config={mockConfig}
-          pickup={mockPickup}
-          popularArticles={mockPopularArticles}
-        />,
+        withMockLegacyRouter(
+          <Search
+            tags={mockTagList}
+            categories={mockCategoryList}
+            config={mockConfig}
+            pickup={mockPickup}
+            popularArticles={mockPopularArticles}
+          />,
+          { query }
+        ),
         { context: { searchParams: params } }
       )
     );
@@ -45,54 +49,53 @@ describe("pages/search", () => {
 
 describe("useNewSearchQueries", () => {
   it("OK: タグで検索したときのクエリが正しい", () => {
-    const params = new URLSearchParams({ tags: mockArticles.stock.tags.map((tag) => tag.id).join(",") });
+    const query = { tags: mockArticles.stock.tags.map((tag) => tag.id).join(",") };
     const Wrapper: React.ComponentType<{ children: React.ReactNode; router?: Partial<AppRouterInstance> }> = ({
       children,
     }) => {
-      return withMockRouter(<>{children}</>, { context: { searchParams: params } });
+      return withMockLegacyRouter(<>{children}</>, { query });
     };
-    const { current } = renderHook(() => useNewSearchQueries(), { wrapper: Wrapper }).result;
+    const { current } = renderHook(() => useNewSearchQueries(query), { wrapper: Wrapper }).result;
 
     expect(current?.filters).toEqual("tags[contains]11[and]tags[contains]9[and]tags[contains]8");
   });
 
   it("OK: カテゴリーで検索したときのクエリが正しい", () => {
-    const params = new URLSearchParams({ category: mockArticles.stock.category.id });
+    const query = { category: mockArticles.stock.category.id };
     const Wrapper: React.ComponentType<{ children: React.ReactNode; router?: Partial<AppRouterInstance> }> = ({
       children,
     }) => {
-      return withMockRouter(<>{children}</>, { context: { searchParams: params } });
+      return withMockLegacyRouter(<>{children}</>, { query });
     };
-    const { current } = renderHook(() => useNewSearchQueries(), { wrapper: Wrapper }).result;
+    const { current } = renderHook(() => useNewSearchQueries(query), { wrapper: Wrapper }).result;
 
     expect(current?.filters).toEqual(`categories[equals]${mockCategories.rice.id}`);
   });
 
   it("OK: 複数のフィルターを組み合わせたときのクエリが正しい", () => {
-    const params = new URLSearchParams({
+    const query = {
       category: mockArticles.stock.category.id,
       q: "基本の",
       tags: mockArticles.stock.tags.map((tag) => tag.id).join(","),
-    });
+    };
     const Wrapper: React.ComponentType<{ children: React.ReactNode; router?: Partial<AppRouterInstance> }> = ({
       children,
     }) => {
-      return withMockRouter(<>{children}</>, { context: { searchParams: params } });
+      return withMockLegacyRouter(<>{children}</>, { query });
     };
-    const { current } = renderHook(() => useNewSearchQueries(), { wrapper: Wrapper }).result;
+    const { current } = renderHook(() => useNewSearchQueries(query), { wrapper: Wrapper }).result;
 
     expect(current?.q).toBe("基本の");
     expect(current?.filters).toBe("categories[equals]1[and]tags[contains]11[and]tags[contains]9[and]tags[contains]8");
   });
 
   it("空クエリの場合undefinedを返す", () => {
-    const params = new URLSearchParams({});
     const Wrapper: React.ComponentType<{ children: React.ReactNode; router?: Partial<AppRouterInstance> }> = ({
       children,
     }) => {
-      return withMockRouter(<>{children}</>, { context: { searchParams: params } });
+      return withMockLegacyRouter(<>{children}</>, { query: {} });
     };
-    const { current } = renderHook(() => useNewSearchQueries(), { wrapper: Wrapper }).result;
+    const { current } = renderHook(() => useNewSearchQueries({}), { wrapper: Wrapper }).result;
 
     expect(current).toBeUndefined();
   });

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "next-themes";
 
 import { SearchProvider } from "@/components/organisms/SearchArea/SearchContext";
 import { GoogleAnalytics } from "@/lib/google-analytics";
+import { notoSansJP } from "@/styles/font";
 
 // FIXME: MSW is broken "ERR_UNSUPPORTED_DIR_IMPORT"
 // if (process.env.NEXT_PUBLIC_MSW_ENABLED === "true") {
@@ -19,15 +20,17 @@ import { GoogleAnalytics } from "@/lib/google-analytics";
 
 const App = ({ Component, pageProps }: AppProps) => {
   return (
-    <div>
+    <>
       <DefaultSeo {...SEO} />
       <GoogleAnalytics />
       <ThemeProvider attribute="class" enableSystem>
         <SearchProvider>
-          <Component {...pageProps} />
+          <div className={`${notoSansJP.variable} font-sans`}>
+            <Component {...pageProps} />
+          </div>
         </SearchProvider>
       </ThemeProvider>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/search/index.page.tsx
+++ b/src/pages/search/index.page.tsx
@@ -21,7 +21,6 @@ export const getStaticProps: GetStaticProps<SearchPageProps> = async () => {
       fetchConfig(),
       getCategories(),
       fetchTags(),
-
       getPickupArticles(new Date()),
       getPopularArticles(),
     ]);

--- a/src/styles/font.ts
+++ b/src/styles/font.ts
@@ -1,0 +1,8 @@
+import { Noto_Sans_JP } from "@next/font/google";
+
+export const notoSansJP = Noto_Sans_JP({
+  style: ["normal"],
+  subsets: ["japanese", "latin"],
+  variable: "--font-noto-sans-jp",
+  weight: ["400", "700"],
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,14 @@
+const { fontFamily } = require("tailwindcss/defaultTheme");
+
 module.exports = {
   content: ["./src/**/*.tsx"],
   darkMode: "class",
+  plugins: [require("@tailwindcss/typography"), require("@tailwindcss/line-clamp")],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ["var(--font-noto-sans-jp)", ...fontFamily.sans],
+      },
       typography: (theme) => ({
         DEFAULT: {
           css: {
@@ -14,6 +20,9 @@ module.exports = {
         },
         dark: {
           css: {
+            a: {
+              color: theme("colors.green.400"),
+            },
             color: theme("colors.gray.300"),
             h1: {
               color: theme("colors.gray.100"),
@@ -21,21 +30,17 @@ module.exports = {
             h2: {
               color: theme("colors.gray.100"),
             },
-            strong: {
-              color: theme("colors.gray.300"),
-            },
-            a: {
-              color: theme("colors.green.400"),
-            },
             li: {
               "&::before": {
                 color: theme("colors.gray.300"),
               },
+            },
+            strong: {
+              color: theme("colors.gray.300"),
             },
           },
         },
       }),
     },
   },
-  plugins: [require("@tailwindcss/typography"), require("@tailwindcss/line-clamp")],
 };


### PR DESCRIPTION
Closes #106 

- feat: `next/font`の導入
- refactor: `next/router`と`next/navigation`を共存するよう変更 
- fix: 検索ページの表示崩れの改善
- fix: 検索時のrouting, data fetchngの最適化
- add: `next/router`, `SearchContext`のモックを実装
- config: dependenciesの整理